### PR TITLE
Add Download Limit to Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,6 +345,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Stop tracking with closing Visual Studio"
+				},
+				"clockify.downloadLimit": {
+					"type": "number",
+					"default": 200,
+					"description": "Limit the number of items that will be downloaded in the tree view"
 				}
 			}
 		}

--- a/src/treeView/clients/clients.providers.ts
+++ b/src/treeView/clients/clients.providers.ts
@@ -19,13 +19,16 @@ export class ClientsProvider implements vscode.TreeDataProvider<ClientProviderIt
 
 	async getChildren(element?: ClientProviderItem): Promise<ClientProviderItem[]> {
 		const workspace = this.context.globalState.get<WorkspaceDto>('selectedWorkspace');
+		const config = vscode.workspace.getConfiguration('clockify');
+		const limit = config.get<number>('downloadLimit')!;
+		
 		if (!workspace) {
 			return [messageTreeItem('Select workspace')];
 		}
 
 		if (!element) {
 			try {
-				const clients = await getClients(workspace.id);
+				const clients = await getClients(workspace.id, undefined, 1, limit);
 				if (clients.length === 0) {
 					return [messageTreeItem('No clients')];
 				}

--- a/src/treeView/projects/projects.provider.ts
+++ b/src/treeView/projects/projects.provider.ts
@@ -21,6 +21,8 @@ export class ProjectsProvider implements vscode.TreeDataProvider<ProjectProvider
 	async getChildren(element?: ProjectProviderItem): Promise<ProjectProviderItem[]> {
 		const workspace = this.context.globalState.get<WorkspaceDto>('selectedWorkspace');
 		const client = this.context.globalState.get<ClientDto>('selectedClient');
+		const config = vscode.workspace.getConfiguration('clockify');
+		const limit = config.get<number>('downloadLimit')!;
 
 		if (!workspace) {
 			return [messageTreeItem('Select workspace')];
@@ -28,7 +30,7 @@ export class ProjectsProvider implements vscode.TreeDataProvider<ProjectProvider
 
 		if (!element) {
 			try {
-				const projects = await getProjects(workspace.id);
+				const projects = await getProjects(workspace.id, undefined, 1, limit);
 				if (projects.length === 0) {
 					return [messageTreeItem('No projects')];
 				}

--- a/src/treeView/tags/tags.provider.ts
+++ b/src/treeView/tags/tags.provider.ts
@@ -19,13 +19,16 @@ export class TagsProvider implements vscode.TreeDataProvider<TagProviderItem> {
 
 	async getChildren(element?: TagProviderItem): Promise<TagProviderItem[]> {
 		const workspace = this.context.globalState.get<WorkspaceDto>('selectedWorkspace');
+		const config = vscode.workspace.getConfiguration('clockify');
+		const limit = config.get<number>('downloadLimit')!;
+
 		if (!workspace) {
 			return [messageTreeItem('Select workspace')];
 		}
 
 		if (!element) {
 			try {
-				const tags = await getTags(workspace.id);
+				const tags = await getTags(workspace.id, undefined, 1, limit);
 				if (tags.length === 0) {
 					return [messageTreeItem('No Tags')];
 				}

--- a/src/treeView/tasks/tasks.provider.ts
+++ b/src/treeView/tasks/tasks.provider.ts
@@ -22,13 +22,16 @@ export class TasksProvider implements vscode.TreeDataProvider<TaskProviderItem> 
 	async getChildren(element?: TaskProviderItem): Promise<TaskProviderItem[]> {
 		const workspace = this.context.globalState.get<WorkspaceDto>('selectedWorkspace');
 		const project = this.context.globalState.get<ProjectDtoImpl>('selectedProject');
+		const config = vscode.workspace.getConfiguration('clockify');
+		const limit = config.get<number>('downloadLimit')!;
+
 		if (!workspace || !project) {
 			return [messageTreeItem('Select project')];
 		}
 
 		if (!element) {
 			try {
-				const tasks = await getTasks(workspace.id, project.id);
+				const tasks = await getTasks(workspace.id, project.id, undefined, undefined, 1, limit);
 				if (tasks.length === 0) {
 					return [messageTreeItem('No Tasks')];
 				}

--- a/src/treeView/timeentries/timeentries.provider.ts
+++ b/src/treeView/timeentries/timeentries.provider.ts
@@ -21,6 +21,9 @@ export class TimeentriesProvider implements vscode.TreeDataProvider<TimeentryPro
 
 	async getChildren(element?: TimeentryProviderItem): Promise<TimeentryProviderItem[]> {
 		const workspace = this.context.globalState.get<WorkspaceDto>('selectedWorkspace');
+		const config = vscode.workspace.getConfiguration('clockify');
+		const limit = config.get<number>('downloadLimit')!;
+		
 		if (!workspace) {
 			return [messageTreeItem('Select workspace')];
 		}
@@ -45,7 +48,7 @@ export class TimeentriesProvider implements vscode.TreeDataProvider<TimeentryPro
 					undefined,
 					undefined,
 					1,
-					100
+					limit
 				);
 				if (timeentries.length === 0) {
 					return [messageTreeItem('No Timeentries')];


### PR DESCRIPTION
The tree view lacks the ability to download more than 50 projects, tasks, etc., making it unusable for larger workspaces.

Adding a setting to let users choose the maximum number of items that are being downloaded solves this problem with little changes to the codebase.
