### PR TITLE
Default to start/stop with workspace settings, if provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "tobiaswaelde",
 	"displayName": "Clockify",
 	"description": "Implements Clockify time tracker (https://clockify.me/) in VSCode",
-	"version": "3.0.12",
+	"version": "3.0.13",
 	"icon": "assets/icon.ico",
 	"galleryBanner": {
 		"color": "#ffffff",

--- a/src/commands/tracking/stopTracking.ts
+++ b/src/commands/tracking/stopTracking.ts
@@ -8,7 +8,7 @@ import { selectWorkspace } from '../selectWorkspace';
 import { updateStatusBarItem } from '../../statusbar/init';
 
 export async function stopTracking(context: vscode.ExtensionContext) {
-	const workspaceId = context.globalState.get<string>('workspaceId');
+	const workspaceId = context.globalState.get<string>('workspaceId') || <string>getConfig('tracking.workspaceId');
 	if (!workspaceId) {
 		context.globalState.update('tracking:isTracking', false);
 		updateStatusBarItem(context);


### PR DESCRIPTION
Previously, if you configured a workspace with clockify settings, they'd only work for "autoStartTracking" and "autoStopTracking".  Now, if these settings are provided, we'll use them to "Start Tracking"/"Stop Tracking" by default instead of asking all this info every time.

If no settings are provided on the workspace, then the behavior remains the same.